### PR TITLE
Overhaul error types, cases and documentation

### DIFF
--- a/Sources/Superb/AnyAuthenticationProvider.swift
+++ b/Sources/Superb/AnyAuthenticationProvider.swift
@@ -3,7 +3,7 @@ import UIKit
 
 internal final class AnyAuthenticationProvider<Token>: _AuthenticationProvider {
   let identifier: String
-  private let _authenticate: (UIViewController, @escaping (Result<Token, SuperbError>) -> Void) -> Void
+  private let _authenticate: (UIViewController, @escaping (AuthenticationResult<Token>) -> Void) -> Void
   private let _authorize: (inout URLRequest, Token) -> Void
 
   init<Base: AuthenticationProvider>(_ provider: Base) where Base.Token == Token {
@@ -12,7 +12,7 @@ internal final class AnyAuthenticationProvider<Token>: _AuthenticationProvider {
     _authorize = { provider.authorize(&$0, with: $1) }
   }
 
-  func authenticate(over viewController: UIViewController, completionHandler: @escaping (Result<Token, SuperbError>) -> Void) {
+  func authenticate(over viewController: UIViewController, completionHandler: @escaping (AuthenticationResult<Token>) -> Void) {
     return _authenticate(viewController, completionHandler)
   }
 

--- a/Sources/Superb/AuthenticationProvider.swift
+++ b/Sources/Superb/AuthenticationProvider.swift
@@ -1,4 +1,3 @@
-import Result
 import UIKit
 
 public protocol CallbackHandler {
@@ -8,7 +7,7 @@ public protocol CallbackHandler {
 public protocol _AuthenticationProvider {
   associatedtype Token
 
-  func authenticate(over viewController: UIViewController, completionHandler: @escaping (Result<Token, SuperbError>) -> Void)
+  func authenticate(over viewController: UIViewController, completionHandler: @escaping (AuthenticationResult<Token>) -> Void)
   func authorize(_ request: inout URLRequest, with token: Token)
 }
 

--- a/Sources/Superb/AuthenticationResult.swift
+++ b/Sources/Superb/AuthenticationResult.swift
@@ -1,0 +1,5 @@
+public enum AuthenticationResult<Token> {
+  case authenticated(Token)
+  case failed(Error)
+  case cancelled
+}

--- a/Sources/Superb/KeychainTokenStorage.swift
+++ b/Sources/Superb/KeychainTokenStorage.swift
@@ -28,7 +28,7 @@ public struct KeychainTokenStorage<Token: KeychainDecodable & KeychainEncodable>
     }
 
     guard status == noErr else {
-      throw SuperbError.keychainAccessFailure(status)
+      throw SuperbError.keychainReadFailure(status)
     }
 
     let data = result as! Data
@@ -50,7 +50,7 @@ public struct KeychainTokenStorage<Token: KeychainDecodable & KeychainEncodable>
 
     let status = SecItemAdd(item, nil)
     guard status == noErr else {
-      throw SuperbError.keychainAccessFailure(status)
+      throw SuperbError.keychainWriteFailure(status)
     }
   }
 
@@ -69,7 +69,7 @@ public struct KeychainTokenStorage<Token: KeychainDecodable & KeychainEncodable>
     }
 
     guard status == noErr else {
-      throw SuperbError.keychainAccessFailure(status)
+      throw SuperbError.keychainWriteFailure(status)
     }
   }
 

--- a/Sources/Superb/RequestAuthorizer.swift
+++ b/Sources/Superb/RequestAuthorizer.swift
@@ -102,7 +102,7 @@ public final class RequestAuthorizer<Token>: RequestAuthorizerProtocol {
       let result: Result<(Data?, URLResponse?), SuperbError>
 
       if let error = error {
-        result = .failure(.requestFailed(error))
+        result = .failure(.requestFailed(request.url, error))
       } else {
         result = .success(data, response)
       }

--- a/Sources/Superb/SuperbError.swift
+++ b/Sources/Superb/SuperbError.swift
@@ -1,27 +1,27 @@
 import Foundation
 
 public enum SuperbError: Error {
-  case authorizationResponseInvalid
+  case authenticationCancelled
+  case authenticationFailed(Error)
   case keychainAccessFailure(OSStatus)
   case keychainDecodeFailure(Data)
   case requestFailed(Error)
-  case unauthorized
   case userInteractionRequired
 }
 
 extension SuperbError: LocalizedError {
   var localizedDescription: String {
     switch self {
-    case .authorizationResponseInvalid:
-      return "😢"
+    case .authenticationCancelled:
+      return "🤷‍♀️"
+    case .authenticationFailed:
+      return "🙅"
     case .keychainAccessFailure(let status):
       return "Keychain access failed: \(status)"
     case .keychainDecodeFailure:
       return "Keychain decode failed"
     case .requestFailed(let error):
       return "SuperbError.requestFailed(\(error.localizedDescription))"
-    case .unauthorized:
-      return "🙅"
     case .userInteractionRequired:
       return "📱🔨"
     }

--- a/Sources/Superb/SuperbError.swift
+++ b/Sources/Superb/SuperbError.swift
@@ -1,29 +1,144 @@
 import Foundation
 
 public enum SuperbError: Error {
+  /// Authentication was cancelled by the user.
   case authenticationCancelled
+
+  /// An error occurred during authentication.
   case authenticationFailed(Error)
-  case keychainAccessFailure(OSStatus)
+
+  /// A problem occurred while reading from the keychain.
+  case keychainReadFailure(OSStatus)
+
+  /// A problem occurred while writing to the keychain.
+  case keychainWriteFailure(OSStatus)
+
+  /// Unable to decode the token data from the keychain.
   case keychainDecodeFailure(Data)
-  case requestFailed(Error)
+
+  /// A HTTP request failed during authentication.
+  case requestFailed(URL?, Error)
+
+  /// Attempted to authenticate, but the top view controller could not be found.
   case userInteractionRequired
 }
 
-extension SuperbError: LocalizedError {
-  var localizedDescription: String {
+extension SuperbError: CustomNSError {
+  public static let errorDomain = "FinchError"
+
+  public var errorCode: Int {
     switch self {
     case .authenticationCancelled:
-      return "🤷‍♀️"
+      return 10
     case .authenticationFailed:
-      return "🙅"
-    case .keychainAccessFailure(let status):
-      return "Keychain access failed: \(status)"
+      return 11
+
+    case .keychainReadFailure:
+      return 20
+    case .keychainWriteFailure:
+      return 21
     case .keychainDecodeFailure:
-      return "Keychain decode failed"
-    case .requestFailed(let error):
-      return "SuperbError.requestFailed(\(error.localizedDescription))"
+      return 22
+
+    case .requestFailed:
+      return 30
+
     case .userInteractionRequired:
-      return "📱🔨"
+      return 40
     }
   }
+
+  public var errorUserInfo: [String : Any] {
+    var userInfo: [String: Any] = [:]
+    userInfo[NSLocalizedDescriptionKey] = errorDescription
+    userInfo[NSLocalizedFailureReasonErrorKey] = failureReason
+    userInfo[NSUnderlyingErrorKey] = underlyingError
+    userInfo[NSURLErrorKey] = url
+    return userInfo
+  }
+}
+
+extension SuperbError: LocalizedError {
+  public var errorDescription: String? {
+    switch self {
+    case .authenticationCancelled,
+         .authenticationFailed,
+         .keychainDecodeFailure,
+         .userInteractionRequired:
+      return failureReason
+
+    case .keychainReadFailure(let code),
+         .keychainWriteFailure(let code):
+      return String(
+        format: NSLocalizedString("Failed to access the keychain (code %@).", bundle: .superb, comment: "Error description for keychain access failure"),
+        arguments: [code]
+      )
+
+    case .requestFailed:
+      return NSLocalizedString("Authentication failed because the server responded with an error.", bundle: .superb, comment: "Error description for authentication request failed")
+    }
+  }
+
+  public var failureReason: String? {
+    switch self {
+    case .authenticationCancelled:
+      return NSLocalizedString("Authentication was cancelled.", bundle: .superb, comment: "Failure reason for authentication cancelled")
+
+    case .authenticationFailed:
+      return NSLocalizedString("Authentication failed.", bundle: .superb, comment: "Failure reason for authentication failed")
+
+    case .keychainReadFailure:
+      return NSLocalizedString("The keychain could not be read.", bundle: .superb, comment: "Failure reason for keychain read failed")
+
+    case .keychainWriteFailure:
+      return NSLocalizedString("The keychain could not be written.", bundle: .superb, comment: "Failure reason for keychain write failed")
+
+    case .keychainDecodeFailure:
+      return NSLocalizedString("The data was not in a recognisable format.", bundle: .superb, comment: "Failure reason for data decode failure")
+
+    case .requestFailed:
+      return NSLocalizedString("The server returned an error.", bundle: .superb, comment: "Failure reason for authentication request failed")
+
+    case .userInteractionRequired:
+      return NSLocalizedString("The user interface was unavailable.", bundle: .superb, comment: "Failure reason for UI unavailable")
+    }
+  }
+
+  public var underlyingError: Error? {
+    switch self {
+    case .authenticationFailed(let error),
+         .requestFailed(_, let error):
+      return error
+
+    case .authenticationCancelled,
+         .keychainReadFailure,
+         .keychainWriteFailure,
+         .keychainDecodeFailure,
+         .userInteractionRequired:
+      return nil
+    }
+  }
+
+  public var url: URL? {
+    switch self {
+    case .requestFailed(let url, _):
+      return url
+
+    case .authenticationCancelled,
+         .authenticationFailed,
+         .keychainReadFailure,
+         .keychainWriteFailure,
+         .keychainDecodeFailure,
+         .userInteractionRequired:
+      return nil
+    }
+  }
+}
+
+private extension Bundle {
+  static var superb: Bundle {
+    return Bundle(for: Superb.self)
+  }
+
+  private final class Superb {}
 }

--- a/Sources/SuperbDemo/GitHubAPIClient.swift
+++ b/Sources/SuperbDemo/GitHubAPIClient.swift
@@ -25,7 +25,7 @@ struct GitHubAPIClient {
     authorizer.performAuthorized(request) { result in
       switch result {
       case let .success(data, _):
-        let object = try! JSONSerialization.jsonObject(with: data!) as! [String: Any]
+        let object = try! JSONSerialization.jsonObject(with: data) as! [String: Any]
         let login = object["login"] as! String
         completionHandler(.success(login))
 

--- a/Sources/SuperbDemo/Providers/GitHubAuthError.swift
+++ b/Sources/SuperbDemo/Providers/GitHubAuthError.swift
@@ -1,0 +1,4 @@
+enum GitHubAuthError: Error {
+  case createAccessTokenFailed(Error)
+  case tokenResponseInvalid(Any?)
+}

--- a/Superb.xcodeproj/project.pbxproj
+++ b/Superb.xcodeproj/project.pbxproj
@@ -48,6 +48,8 @@
 		4AAA9F8F1E1C82B00064F4C9 /* Nimble.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 4AAA9F8A1E1C82950064F4C9 /* Nimble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		4AAA9F901E1C82B00064F4C9 /* Quick.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 4AAA9F8B1E1C82950064F4C9 /* Quick.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		4AE2AAE61E412C3400547D10 /* ProviderRegistration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AE2AAE51E412C3400547D10 /* ProviderRegistration.swift */; };
+		4AFBA60D1E426EF000A570D0 /* AuthenticationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AFBA60C1E426EF000A570D0 /* AuthenticationResult.swift */; };
+		4AFBA6101E42742400A570D0 /* GitHubAuthError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AFBA60E1E42741F00A570D0 /* GitHubAuthError.swift */; };
 		7016D5811DFB0B9A00B594ED /* GitHubBasicAuthProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7016D5801DFB0B9A00B594ED /* GitHubBasicAuthProvider.swift */; };
 		7016D5831DFB11FD00B594ED /* GitHubBasicAuthViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7016D5821DFB11FD00B594ED /* GitHubBasicAuthViewController.swift */; };
 /* End PBXBuildFile section */
@@ -138,6 +140,8 @@
 		4AAA9F8B1E1C82950064F4C9 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/iOS/Quick.framework; sourceTree = "<group>"; };
 		4AE2AAE51E412C3400547D10 /* ProviderRegistration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProviderRegistration.swift; sourceTree = "<group>"; };
 		4AF7D78C1E1C0CA8003847BD /* Channel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Channel.swift; sourceTree = "<group>"; };
+		4AFBA60C1E426EF000A570D0 /* AuthenticationResult.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticationResult.swift; sourceTree = "<group>"; };
+		4AFBA60E1E42741F00A570D0 /* GitHubAuthError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GitHubAuthError.swift; sourceTree = "<group>"; };
 		7016D5801DFB0B9A00B594ED /* GitHubBasicAuthProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GitHubBasicAuthProvider.swift; sourceTree = "<group>"; };
 		7016D5821DFB11FD00B594ED /* GitHubBasicAuthViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GitHubBasicAuthViewController.swift; sourceTree = "<group>"; };
 		70DD2AF81DFB08CA00DD9695 /* GitHubBasicAuth.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = GitHubBasicAuth.storyboard; sourceTree = "<group>"; };
@@ -180,6 +184,7 @@
 				4AA980C31DFB5FD6000604FB /* AnyAuthenticationProvider.swift */,
 				4A90A4FF1E09F31F0077BC68 /* Atomic.swift */,
 				4A3776831DF9C8D8005480A1 /* AuthenticationProvider.swift */,
+				4AFBA60C1E426EF000A570D0 /* AuthenticationResult.swift */,
 				4A8BDBA91E2DD0E600F29E62 /* AuthenticationState.swift */,
 				4AF7D78C1E1C0CA8003847BD /* Channel.swift */,
 				4A9FE9121E2AFCCE0029C645 /* KeychainEncoding.swift */,
@@ -249,6 +254,7 @@
 			children = (
 				4A9061AD1DF9BD980004D532 /* GitHubOAuth.storyboard */,
 				70DD2AF81DFB08CA00DD9695 /* GitHubBasicAuth.storyboard */,
+				4AFBA60E1E42741F00A570D0 /* GitHubAuthError.swift */,
 				4A3776811DF9C6BA005480A1 /* GitHubOAuthProvider.swift */,
 				4A9061AF1DF9C08C0004D532 /* GitHubOAuthViewController.swift */,
 				7016D5801DFB0B9A00B594ED /* GitHubBasicAuthProvider.swift */,
@@ -489,6 +495,7 @@
 				4A6A822E1E3BABB500A7D899 /* SimpleTokenStorage.swift in Sources */,
 				4A6A82281E3BABB500A7D899 /* Channel.swift in Sources */,
 				4A6A822D1E3BABB500A7D899 /* RequestAuthorizer.swift in Sources */,
+				4AFBA60D1E426EF000A570D0 /* AuthenticationResult.swift in Sources */,
 				4A6A82271E3BABB500A7D899 /* AuthenticationState.swift in Sources */,
 				4A6A822F1E3BABB500A7D899 /* TokenStorage.swift in Sources */,
 				4A6A822B1E3BABB500A7D899 /* KeychainEncoding.swift in Sources */,
@@ -510,6 +517,7 @@
 				4A90618C1DF9BB4A0004D532 /* AppDelegate.swift in Sources */,
 				4AA26C711E3FD4D300767E66 /* GitHubAPIClient.swift in Sources */,
 				7016D5811DFB0B9A00B594ED /* GitHubBasicAuthProvider.swift in Sources */,
+				4AFBA6101E42742400A570D0 /* GitHubAuthError.swift in Sources */,
 				4A3776821DF9C6BA005480A1 /* GitHubOAuthProvider.swift in Sources */,
 				4AA26C6D1E3FD2CF00767E66 /* GitHub+Providers.swift in Sources */,
 			);

--- a/Tests/SuperbTests/RequestAuthorizerSpec.swift
+++ b/Tests/SuperbTests/RequestAuthorizerSpec.swift
@@ -38,7 +38,7 @@ final class RequestAuthorizerSpec: QuickSpec {
 
       authorizer.performAuthorized(request) { _ in }
 
-      testProvider.complete(with: "dynamic-token")
+      testProvider.complete(with: .authenticated("dynamic-token"))
 
       requests.verify()
     }
@@ -64,7 +64,7 @@ final class RequestAuthorizerSpec: QuickSpec {
         error = result.error
       }
 
-      testProvider.complete(with: "new-token")
+      testProvider.complete(with: .authenticated("new-token"))
 
       requests.verify()
       expect(response?.statusCode).toEventually(equal(200))
@@ -98,7 +98,7 @@ final class RequestAuthorizerSpec: QuickSpec {
 
       group.wait()
 
-      testProvider.complete(with: "shared-token")
+      testProvider.complete(with: .authenticated("shared-token"))
 
       requests.verify()
       expect(statusCodes.count).toEventually(equal(limit))
@@ -130,12 +130,12 @@ final class RequestAuthorizerSpec: QuickSpec {
 
       group.wait()
 
-      testProvider.complete(with: .unauthorized)
+      testProvider.complete(with: .cancelled)
 
-      var allUnauthorized: Bool {
+      var allCancelled: Bool {
         for error in errors {
           switch error {
-          case .unauthorized:
+          case .authenticationCancelled:
             continue
           default:
             return false
@@ -146,7 +146,7 @@ final class RequestAuthorizerSpec: QuickSpec {
 
       requests.verify()
       expect(errors.count).toEventually(equal(limit))
-      expect(allUnauthorized).to(beTrue())
+      expect(allCancelled).to(beTrue())
     }
 
     describe("token storage") {
@@ -159,7 +159,7 @@ final class RequestAuthorizerSpec: QuickSpec {
         requests.expect(where: isPath("/example"))
 
         authorizer.performAuthorized(request) { _ in }
-        testProvider.complete(with: "new-token")
+        testProvider.complete(with: .authenticated("new-token"))
 
         expect(testTokenStorage.fetchToken()).toEventually(equal("new-token"))
 


### PR DESCRIPTION
It felt weird to me that `AuthenticationProvider` allowed users to return an arbitrary `SuperbError` as a result. The job of `SuperbError` should be to report errors from within Superb, not from third party authentication providers. So this introduces a new type, `AuthenticationResult<Token>`, that encapsulates what can happen as a result of authenticating (at least at the moment):

- Success, with an associated `Token`.
- Failure, with an associated `Error`.
- Cancelled by the user.

The error handling of the GitHub providers has already improved as a result.

Additionally, this adds real localizable error messages and validates that `Data` and `URLResponse` are non-nil when an authorized request completes.

Fixes #16.
Fixes #19.