### PR TITLE
Don't build SuperbDemo from the shared scheme

### DIFF
--- a/Superb.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/Superb.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded</key>
-	<false/>
+	<true/>
 </dict>
 </plist>

--- a/Superb.xcodeproj/xcshareddata/xcschemes/Superb.xcscheme
+++ b/Superb.xcodeproj/xcshareddata/xcschemes/Superb.xcscheme
@@ -22,7 +22,7 @@
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "YES"
+            buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
             buildForAnalyzing = "NO">
@@ -56,9 +56,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "4A6A82161E3BAB3900A7D899"
-            BuildableName = "Superb.framework"
-            BlueprintName = "Superb"
+            BlueprintIdentifier = "4A9061871DF9BB4A0004D532"
+            BuildableName = "SuperbDemo.app"
+            BlueprintName = "SuperbDemo"
             ReferencedContainer = "container:Superb.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -75,16 +75,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "4A9061871DF9BB4A0004D532"
-            BuildableName = "SuperbDemo.app"
-            BlueprintName = "SuperbDemo"
-            ReferencedContainer = "container:Superb.xcodeproj">
-         </BuildableReference>
-      </BuildableProductRunnable>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>


### PR DESCRIPTION
For convenience, Super.xcscheme was configured to build SuperbDemo in the Run action. Unfortunately this also caused SuperbDemo to be built unintentionally when building as a Carthage framework. The result is that `bin/validate-secrets` would run, failing the build because secrets are not set up in the Carthage environment.

This change does two things: first, it removes SuperbDemo from the shared Superb scheme for building, restricting it to only build when running the tests. This means that during development the SuperbDemo target is not available for running, so we re-enable the "Autocreate Schemes" option in Xcode so that a SuperbDemo scheme is created for development purposes.