### PR TITLE
Ensure tags are fetched when validating podspec on CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,6 +2,10 @@ machine:
   xcode:
     version: "8.3"
 
+checkout:
+  post:
+    - git fetch --unshallow
+
 dependencies:
   override:
     - bin/bootstrap-if-needed


### PR DESCRIPTION
See: https://discuss.circleci.com/t/where-are-my-git-tags/2371/2.

Circle CI's default behaviour of making a shallow clone causes the `git describe --tags` invocation in the podspec to fail.