### PR TITLE
Rename 'authorizationProvider' to 'authenticationProvider'

### DIFF
--- a/Sources/Superb/Deprecations+Removals.swift
+++ b/Sources/Superb/Deprecations+Removals.swift
@@ -1,0 +1,19 @@
+import UIKit
+
+public extension RequestAuthorizer {
+  @available(*, unavailable, renamed: "init(authenticationProvider:tokenStorage:applicationDelegate:urlSession:)")
+  convenience init<Provider: AuthenticationProvider, Storage: TokenStorage>(authorizationProvider: Provider, tokenStorage: Storage, applicationDelegate: @autoclosure @escaping () -> UIApplicationDelegate? = nil, urlSession: URLSession = .shared)
+    where Provider.Token == Token, Storage.Token == Token
+  {
+    fatalError("unavailable")
+  }
+}
+
+public extension RequestAuthorizer where Token: KeychainDecodable & KeychainEncodable {
+  @available(*, unavailable, renamed: "init(authenticationProvider:applicationDelegate:urlSession:)")
+  convenience init<Provider: AuthenticationProvider>(authorizationProvider: Provider, applicationDelegate: @autoclosure @escaping () -> UIApplicationDelegate? = nil, urlSession: URLSession = .shared)
+    where Provider.Token == Token
+  {
+    fatalError("unavailable")
+  }
+}

--- a/Sources/Superb/RequestAuthorizer.swift
+++ b/Sources/Superb/RequestAuthorizer.swift
@@ -13,13 +13,13 @@ public final class RequestAuthorizer<Token>: RequestAuthorizerProtocol {
   private let authenticationComplete: Channel<AuthenticationResult<Token>>
   private let authenticationState: Actor<AuthenticationState<Token>>
 
-  public init<Provider: AuthenticationProvider, Storage: TokenStorage>(authorizationProvider: Provider, tokenStorage: Storage, applicationDelegate: @autoclosure @escaping () -> UIApplicationDelegate? = defaultApplicationDelegate, urlSession: URLSession = .shared)
+  public init<Provider: AuthenticationProvider, Storage: TokenStorage>(authenticationProvider: Provider, tokenStorage: Storage, applicationDelegate: @autoclosure @escaping () -> UIApplicationDelegate? = defaultApplicationDelegate, urlSession: URLSession = .shared)
     where Provider.Token == Token, Storage.Token == Token
   {
     self.applicationDelegate = applicationDelegate
     self.authenticationComplete = Channel()
     self.authenticationState = AuthenticationState.makeActor(tokenStorage: tokenStorage)
-    self.authenticationProvider = AnyAuthenticationProvider(authorizationProvider)
+    self.authenticationProvider = AnyAuthenticationProvider(authenticationProvider)
     self.urlSession = urlSession
   }
 
@@ -282,11 +282,11 @@ public final class RequestAuthorizer<Token>: RequestAuthorizerProtocol {
 }
 
 extension RequestAuthorizer where Token: KeychainDecodable & KeychainEncodable {
-  public convenience init<Provider: AuthenticationProvider>(authorizationProvider: Provider, applicationDelegate: @autoclosure @escaping () -> UIApplicationDelegate? = defaultApplicationDelegate, urlSession: URLSession = .shared)
+  public convenience init<Provider: AuthenticationProvider>(authenticationProvider: Provider, applicationDelegate: @autoclosure @escaping () -> UIApplicationDelegate? = defaultApplicationDelegate, urlSession: URLSession = .shared)
     where Provider.Token == Token
   {
     let keychainTokenStorage = KeychainTokenStorage<Token>(service: Provider.keychainServiceName, label: Provider.identifier)
-    self.init(authorizationProvider: authorizationProvider, tokenStorage: keychainTokenStorage, applicationDelegate: applicationDelegate, urlSession: urlSession)
+    self.init(authenticationProvider: authenticationProvider, tokenStorage: keychainTokenStorage, applicationDelegate: applicationDelegate, urlSession: urlSession)
   }
 }
 

--- a/Sources/SuperbDemo/GitHubAPIClient.swift
+++ b/Sources/SuperbDemo/GitHubAPIClient.swift
@@ -4,13 +4,13 @@ import Superb
 struct GitHubAPIClient {
   static let basicAuthClient = GitHubAPIClient(
     requestAuthorizer: RequestAuthorizer(
-      authorizationProvider: GitHubBasicAuthProvider.shared
+      authenticationProvider: GitHubBasicAuthProvider.shared
     )
   )
 
   static let oauthClient = GitHubAPIClient(
     requestAuthorizer: RequestAuthorizer(
-      authorizationProvider: GitHubOAuthProvider.shared
+      authenticationProvider: GitHubOAuthProvider.shared
     )
   )
 

--- a/Superb.xcodeproj/project.pbxproj
+++ b/Superb.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		4A3776821DF9C6BA005480A1 /* GitHubOAuthProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3776811DF9C6BA005480A1 /* GitHubOAuthProvider.swift */; };
+		4A4FA2C21F4B8A170033E59E /* Deprecations+Removals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A4FA2C11F4B8A170033E59E /* Deprecations+Removals.swift */; };
 		4A6A821E1E3BAB3900A7D899 /* Superb.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A6A82171E3BAB3900A7D899 /* Superb.framework */; };
 		4A6A821F1E3BAB3900A7D899 /* Superb.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 4A6A82171E3BAB3900A7D899 /* Superb.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		4A6A82241E3BABB500A7D899 /* Actor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A80B72E1E3260B600CD49B7 /* Actor.swift */; };
@@ -109,6 +110,7 @@
 		4A3776811DF9C6BA005480A1 /* GitHubOAuthProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GitHubOAuthProvider.swift; sourceTree = "<group>"; };
 		4A3776831DF9C8D8005480A1 /* AuthenticationProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticationProvider.swift; sourceTree = "<group>"; };
 		4A4460C11ECA453A0034FC59 /* Profile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Profile.swift; sourceTree = "<group>"; };
+		4A4FA2C11F4B8A170033E59E /* Deprecations+Removals.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Deprecations+Removals.swift"; sourceTree = "<group>"; };
 		4A6A82171E3BAB3900A7D899 /* Superb.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Superb.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4A6A82301E3BAEAB00A7D899 /* Superb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Superb.h; sourceTree = "<group>"; };
 		4A6A82311E3BAEAB00A7D899 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -204,6 +206,7 @@
 				4AFBA60C1E426EF000A570D0 /* AuthenticationResult.swift */,
 				4A8BDBA91E2DD0E600F29E62 /* AuthenticationState.swift */,
 				4AF7D78C1E1C0CA8003847BD /* Channel.swift */,
+				4A4FA2C11F4B8A170033E59E /* Deprecations+Removals.swift */,
 				4A9FE9121E2AFCCE0029C645 /* KeychainEncoding.swift */,
 				4A9FE90D1E2AF0BD0029C645 /* KeychainTokenStorage.swift */,
 				4AC65E6C1ECA3ADF009D43A0 /* NilCoalescing.swift */,
@@ -513,6 +516,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4A6A82251E3BABB500A7D899 /* AnyAuthenticationProvider.swift in Sources */,
+				4A4FA2C21F4B8A170033E59E /* Deprecations+Removals.swift in Sources */,
 				4A6A822C1E3BABB500A7D899 /* KeychainTokenStorage.swift in Sources */,
 				4A6A82291E3BABB500A7D899 /* SuperbError.swift in Sources */,
 				4A6A822E1E3BABB500A7D899 /* SimpleTokenStorage.swift in Sources */,

--- a/Tests/SuperbTests/RequestAuthorizerSpec.swift
+++ b/Tests/SuperbTests/RequestAuthorizerSpec.swift
@@ -21,7 +21,7 @@ final class RequestAuthorizerSpec: QuickSpec {
     it("authorizes a request with the current token") {
       let testProvider = TestAuthenticationProvider()
       let testTokenStorage = SimpleTokenStorage(token: "test-token")
-      let authorizer = RequestAuthorizer(authorizationProvider: testProvider, tokenStorage: testTokenStorage)
+      let authorizer = RequestAuthorizer(authenticationProvider: testProvider, tokenStorage: testTokenStorage)
       let request = testRequest(path: "/example")
 
       requests.expect(where: isPath("/example") && hasHeaderNamed("Authorization", value: "test-token"))
@@ -31,7 +31,7 @@ final class RequestAuthorizerSpec: QuickSpec {
 
     it("calls the request authorizer when unathenticated") {
       let testProvider = TestAuthenticationProvider()
-      let authorizer = RequestAuthorizer(authorizationProvider: testProvider, tokenStorage: SimpleTokenStorage())
+      let authorizer = RequestAuthorizer(authenticationProvider: testProvider, tokenStorage: SimpleTokenStorage())
       let request = testRequest(path: "/example")
 
       requests.expect(where: isPath("/example") && hasHeaderNamed("Authorization", value: "dynamic-token"))
@@ -46,7 +46,7 @@ final class RequestAuthorizerSpec: QuickSpec {
     it("calls the request authorizer and retries on a 401 response") {
       let testProvider = TestAuthenticationProvider()
       let testTokenStorage = SimpleTokenStorage(token: "stale-token")
-      let authorizer = RequestAuthorizer(authorizationProvider: testProvider, tokenStorage: testTokenStorage)
+      let authorizer = RequestAuthorizer(authenticationProvider: testProvider, tokenStorage: testTokenStorage)
       let request = testRequest(path: "/example")
 
       requests.expect(
@@ -73,7 +73,7 @@ final class RequestAuthorizerSpec: QuickSpec {
 
     it("authorizes multiple pending requests") {
       let testProvider = TestAuthenticationProvider()
-      let authorizer = RequestAuthorizer(authorizationProvider: testProvider, tokenStorage: SimpleTokenStorage())
+      let authorizer = RequestAuthorizer(authenticationProvider: testProvider, tokenStorage: SimpleTokenStorage())
 
       var statusCodes: [Int] = []
       let queue = DispatchQueue(label: "response queue")
@@ -107,7 +107,7 @@ final class RequestAuthorizerSpec: QuickSpec {
 
     it("notifies multiple pending requests of authentication failure") {
       let testProvider = TestAuthenticationProvider()
-      let authorizer = RequestAuthorizer(authorizationProvider: testProvider, tokenStorage: SimpleTokenStorage())
+      let authorizer = RequestAuthorizer(authenticationProvider: testProvider, tokenStorage: SimpleTokenStorage())
 
       var errors: [SuperbError] = []
       let queue = DispatchQueue(label: "response queue")
@@ -153,7 +153,7 @@ final class RequestAuthorizerSpec: QuickSpec {
       it("updates the stored token after authenticating") {
         let testProvider = TestAuthenticationProvider()
         let testTokenStorage = SimpleTokenStorage<String>()
-        let authorizer = RequestAuthorizer(authorizationProvider: testProvider, tokenStorage: testTokenStorage)
+        let authorizer = RequestAuthorizer(authenticationProvider: testProvider, tokenStorage: testTokenStorage)
         let request = testRequest(path: "/example")
 
         requests.expect(where: isPath("/example"))
@@ -170,7 +170,7 @@ final class RequestAuthorizerSpec: QuickSpec {
     describe("clearToken") {
       it("removes the token from token storage") {
         let testTokenStorage = SimpleTokenStorage(token: "some-token")
-        let authorizer = RequestAuthorizer(authorizationProvider: TestAuthenticationProvider(), tokenStorage: testTokenStorage)
+        let authorizer = RequestAuthorizer(authenticationProvider: TestAuthenticationProvider(), tokenStorage: testTokenStorage)
 
         try? authorizer.clearToken()
 
@@ -180,7 +180,7 @@ final class RequestAuthorizerSpec: QuickSpec {
       it("doesn't affect pending requests while authenticating") {
         let testProvider = TestAuthenticationProvider()
         let testTokenStorage = SimpleTokenStorage(token: "old-token")
-        let authorizer = RequestAuthorizer(authorizationProvider: testProvider, tokenStorage: testTokenStorage)
+        let authorizer = RequestAuthorizer(authenticationProvider: testProvider, tokenStorage: testTokenStorage)
         let request = testRequest(path: "/example")
 
         requests.expect(where: isPath("/example") && hasHeaderNamed("Authorization", value: "new-token"))


### PR DESCRIPTION
This completes the rename started in c873afb477fbb0f65f83502661898c86553ff0a3 (this parameter label was missed).